### PR TITLE
Add settings to hide lists in certain places

### DIFF
--- a/app/views/issues/issue_todo_lists/_issue_todo_lists_issues_form.html.erb
+++ b/app/views/issues/issue_todo_lists/_issue_todo_lists_issues_form.html.erb
@@ -3,7 +3,7 @@
   User.current.admin? || User.current.allowed_to?(:add_issue_todo_list_items, list.project) ||
     (!issue.new_record? && User.current.allowed_to?(:remove_issue_todo_list_items, list.project) && list.issue_todo_list_items.exists?(issue_id: issue.id))
 end %>
-<% if allowed_todo_lists.count.positive? %>
+<% if allowed_todo_lists.count.positive? && Setting.plugin_redmine_issue_todo_lists2['show_in_issue_edit'] %>
   <p>
     <%= form.label :selected_todo_lists, l(:issue_todo_lists_title) %>
     <%= form.collection_select :issue_todo_list_ids, allowed_todo_lists, :id, lambda { |list| "#{list.project.name}: #{list.title}" }, {}, { multiple: true, selected: issue.issue_todo_list_ids } %>

--- a/app/views/issues/issue_todo_lists/_issue_todo_lists_link.erb
+++ b/app/views/issues/issue_todo_lists/_issue_todo_lists_link.erb
@@ -1,36 +1,38 @@
-<% content_for :sidebar do %>
-  <% todo_lists = IssueTodoList.where(project_id: @project.self_and_ancestors.ids).order('project_id', 'title') %>
-  <% if IssueTodoListsHelper.has_todo_lists_permission?(@project.self_and_ancestors) && todo_lists.count > 0 -%>
-    <h3><%= l(:issue_todo_lists_title) %></h3>
-    <ul>
-      <% todo_lists.each do |todo_list| %>
-        <% if User.current.admin? || User.current.allowed_to?(:view_issue_todo_lists, todo_list.project) -%>
-          <li>
-            <%= link_to todo_list.project.name + ': ' + todo_list.title, project_issue_todo_list_path(todo_list.project, todo_list) %>
-            <% if (User.current.admin? || User.current.allowed_to?(:add_issue_todo_list_items, todo_list.project)) && !todo_list.issues.include?(@issue) %>
-              <%= link_to image_tag('link.png'),
-                          bulk_allocate_issues_project_issue_todo_list_path(todo_list.project, todo_list, :issue_ids => [@issue.id], :back_url => issue_path(@issue.id)),
-                          :method => :post,
-                          :title => l(:label_relation_new)
-              %>
-            <% elsif !todo_list.issues.include?(@issue) %>
-              <%= image_tag('link.png') %>
-            <% end %>
-            <% if (User.current.admin? || User.current.allowed_to?(:remove_issue_todo_list_items, todo_list.project)) && todo_list.issues.include?(@issue) %>
-              <%= link_to image_tag('link_break.png'),
-                          project_issue_todo_list_item_path(todo_list.project, todo_list, IssueTodoListItem.where(issue_todo_list_id: todo_list.id, issue_id: @issue.id).ids.first, :back_url => issue_path(@issue.id)),
-                          :remote => false,
-                          :method => :delete,
-                          :data => {:confirm => l(:text_are_you_sure)},
-                          :title => l(:label_relation_delete)
-              %>
-            <% elsif todo_list.issues.include?(@issue) %>
-              <%= image_tag('link_break.png') %>
-            <% end %>
-          </li>
+<% if Setting.plugin_redmine_issue_todo_lists2['show_in_issue_sidebar'] %>
+  <% content_for :sidebar do %>
+    <% todo_lists = IssueTodoList.where(project_id: @project.self_and_ancestors.ids).order('project_id', 'title') %>
+    <% if IssueTodoListsHelper.has_todo_lists_permission?(@project.self_and_ancestors) && todo_lists.count > 0 -%>
+      <h3><%= l(:issue_todo_lists_title) %></h3>
+      <ul>
+        <% todo_lists.each do |todo_list| %>
+          <% if User.current.admin? || User.current.allowed_to?(:view_issue_todo_lists, todo_list.project) -%>
+            <li>
+              <%= link_to todo_list.project.name + ': ' + todo_list.title, project_issue_todo_list_path(todo_list.project, todo_list) %>
+              <% if (User.current.admin? || User.current.allowed_to?(:add_issue_todo_list_items, todo_list.project)) && !todo_list.issues.include?(@issue) %>
+                <%= link_to image_tag('link.png'),
+                            bulk_allocate_issues_project_issue_todo_list_path(todo_list.project, todo_list, :issue_ids => [@issue.id], :back_url => issue_path(@issue.id)),
+                            :method => :post,
+                            :title => l(:label_relation_new)
+                %>
+              <% elsif !todo_list.issues.include?(@issue) %>
+                <%= image_tag('link.png') %>
+              <% end %>
+              <% if (User.current.admin? || User.current.allowed_to?(:remove_issue_todo_list_items, todo_list.project)) && todo_list.issues.include?(@issue) %>
+                <%= link_to image_tag('link_break.png'),
+                            project_issue_todo_list_item_path(todo_list.project, todo_list, IssueTodoListItem.where(issue_todo_list_id: todo_list.id, issue_id: @issue.id).ids.first, :back_url => issue_path(@issue.id)),
+                            :remote => false,
+                            :method => :delete,
+                            :data => {:confirm => l(:text_are_you_sure)},
+                            :title => l(:label_relation_delete)
+                %>
+              <% elsif todo_list.issues.include?(@issue) %>
+                <%= image_tag('link_break.png') %>
+              <% end %>
+            </li>
+          <% end %>
         <% end %>
-      <% end %>
-    </ul>
+      </ul>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/settings/_issue_todo_lists_settings.html.erb
+++ b/app/views/settings/_issue_todo_lists_settings.html.erb
@@ -9,5 +9,5 @@
 <fieldset class="box tabular settings">
   <legend><%= l(:label_general_issue_todo_lists_settings) %></legend>
   <%= render_check_box('enable_dates_context_menu') %>
+  <%= render_check_box('show_in_issue_sidebar') %>
 </fieldset>
-

--- a/app/views/settings/_issue_todo_lists_settings.html.erb
+++ b/app/views/settings/_issue_todo_lists_settings.html.erb
@@ -10,4 +10,5 @@
   <legend><%= l(:label_general_issue_todo_lists_settings) %></legend>
   <%= render_check_box('enable_dates_context_menu') %>
   <%= render_check_box('show_in_issue_sidebar') %>
+  <%= render_check_box('show_in_issue_edit') %>
 </fieldset>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -24,4 +24,5 @@ de:
   issue_todo_lists_item_create_empty: Aufgabenfeld darf nicht leer sein
   field_dates: Daten
   label_enable_dates_context_menu: Datums im Kontextmenü aktivieren
+  label_show_in_issue_sidebar: Aufgabenliste in der Seitenleiste des Problems anzeigen
   label_general_issue_todo_lists_settings: Allgemeine Einstellungen für Aufgabenlisten bei Problemen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -25,4 +25,5 @@ de:
   field_dates: Daten
   label_enable_dates_context_menu: Datums im Kontextmenü aktivieren
   label_show_in_issue_sidebar: Aufgabenliste in der Seitenleiste des Problems anzeigen
+  label_show_in_issue_edit: Zeigen Sie beim Erstellen oder Bearbeiten von Problemen Aufgabenlisten an
   label_general_issue_todo_lists_settings: Allgemeine Einstellungen für Aufgabenlisten bei Problemen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,4 +25,5 @@ en:
   field_dates: Dates
   label_enable_dates_context_menu: Enable dates in the context menu
   label_show_in_issue_sidebar: Show todo lists in issue sidebar
+  label_show_in_issue_edit: Show todo lists when creating or editing issues
   label_general_issue_todo_lists_settings: General Issue Todo Lists Settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,4 +24,5 @@ en:
   issue_todo_lists_item_create_empty: Issue field cannot be blank
   field_dates: Dates
   label_enable_dates_context_menu: Enable dates in the context menu
+  label_show_in_issue_sidebar: Show todo lists in issue sidebar
   label_general_issue_todo_lists_settings: General Issue Todo Lists Settings

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -25,4 +25,5 @@ es:
   field_dates: Fechas
   label_enable_dates_context_menu: Habilitar fechas en el menú contextual
   label_show_in_issue_sidebar: Mostrar listas de tareas pendientes en la barra lateral de problemas
+  label_show_in_issue_edit: Mostrar listas de tareas pendientes al crear o editar problemas
   label_general_issue_todo_lists_settings: Configuración general de listas de tareas de problemas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -24,4 +24,5 @@ es:
   issue_todo_lists_item_create_empty: El campo de la tarea no puede estar vacío
   field_dates: Fechas
   label_enable_dates_context_menu: Habilitar fechas en el menú contextual
+  label_show_in_issue_sidebar: Mostrar listas de tareas pendientes en la barra lateral de problemas
   label_general_issue_todo_lists_settings: Configuración general de listas de tareas de problemas

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -25,4 +25,5 @@ fr:
   field_dates: Dates
   label_enable_dates_context_menu: Activer les dates dans le menu contextuel
   label_show_in_issue_sidebar: Afficher les listes de tâches dans la barre latérale du problème
+  label_show_in_issue_edit: Afficher les listes de tâches lors de la création ou de la modification de problèmes
   label_general_issue_todo_lists_settings: Paramètres généraux des listes de tâches pour les problèmes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,6 +24,5 @@ fr:
   issue_todo_lists_item_create_empty: Le champ de la tâche ne peut pas être vide
   field_dates: Dates
   label_enable_dates_context_menu: Activer les dates dans le menu contextuel
+  label_show_in_issue_sidebar: Afficher les listes de tâches dans la barre latérale du problème
   label_general_issue_todo_lists_settings: Paramètres généraux des listes de tâches pour les problèmes
-
-

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -24,4 +24,5 @@ nl:
   issue_todo_lists_item_create_empty: Taakveld kan niet leeg zijn
   field_dates: Data
   label_enable_dates_context_menu: Data inschakelen in het contextmenu
+  label_show_in_issue_sidebar: Toon takenlijst in de issue zijbalk
   label_general_issue_todo_lists_settings: Algemene instellingen voor takenlijsten bij issues

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -25,4 +25,5 @@ nl:
   field_dates: Data
   label_enable_dates_context_menu: Data inschakelen in het contextmenu
   label_show_in_issue_sidebar: Toon takenlijst in de issue zijbalk
+  label_show_in_issue_edit: Toon takenlijst bij het creëren of bewerken van issues
   label_general_issue_todo_lists_settings: Algemene instellingen voor takenlijsten bij issues

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -25,4 +25,5 @@ zh:
   field_dates: 日期
   label_enable_dates_context_menu: 启用上下文菜单中的日期
   label_show_in_issue_sidebar: 在问题侧边栏中显示待办事项列表
+  label_show_in_issue_edit: 创建或编辑问题时显示待办事项列表
   label_general_issue_todo_lists_settings: 问题待办事项列表的常规设置

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -24,4 +24,5 @@ zh:
   issue_todo_lists_item_create_empty: 任务字段不能为空
   field_dates: 日期
   label_enable_dates_context_menu: 启用上下文菜单中的日期
+  label_show_in_issue_sidebar: 在问题侧边栏中显示待办事项列表
   label_general_issue_todo_lists_settings: 问题待办事项列表的常规设置

--- a/init.rb
+++ b/init.rb
@@ -22,7 +22,8 @@ Redmine::Plugin.register :redmine_issue_todo_lists2 do
 
   settings default: {
     'enable_dates_context_menu' => true,
-    'show_in_issue_sidebar'     => true
+    'show_in_issue_sidebar'     => true,
+    'show_in_issue_edit'        => true
   }, partial: 'settings/issue_todo_lists_settings'
 
   menu :project_menu, :issue_todo_lists, { :controller => 'issue_todo_lists', :action => 'index' }, :caption => :issue_todo_lists_title, :param => :project_id, :after => :activity

--- a/init.rb
+++ b/init.rb
@@ -21,7 +21,8 @@ Redmine::Plugin.register :redmine_issue_todo_lists2 do
   end
 
   settings default: {
-    'enable_dates_context_menu' => true
+    'enable_dates_context_menu' => true,
+    'show_in_issue_sidebar'     => true
   }, partial: 'settings/issue_todo_lists_settings'
 
   menu :project_menu, :issue_todo_lists, { :controller => 'issue_todo_lists', :action => 'index' }, :caption => :issue_todo_lists_title, :param => :project_id, :after => :activity


### PR DESCRIPTION
To make configurable where to show todo-lists, we added settings to hide/show lists:

- When creating or editing issues.
- In the sidebar.